### PR TITLE
swap lowercase x with mult symbol for fast streaks

### DIFF
--- a/packages/burrow/dice.ts
+++ b/packages/burrow/dice.ts
@@ -49,8 +49,8 @@ export const adornName = (params: AdornParams) => {
 };
 
 export function multiply(str: string, n: number): string {
-  if (n === 69) return `${str} x69 (nice)`;
-  return n < 20 ? str.repeat(n) : `${str} x${n}`;
+  if (n === 69) return `${str} ×69 (nice)`;
+  return n < 20 ? str.repeat(n) : `${str} ×${n}`;
 }
 
 const DOUBLES = ['🍒', '✌️', '🫁', '👯', '🤼', '🫂', '🎎', '🙌', '🖇️', '⚔️', '🛠️', '⛓️', '🛍️', '🚻', '👣', '🧦', '🩰', '⚖️', '🧬', '🎵', '♊', '🪺'];


### PR DESCRIPTION
“x” as in “xylophone” ≠ “×” as in “2×3=6”